### PR TITLE
Add support for setting a custom base_url on open news providers

### DIFF
--- a/mc_providers/__init__.py
+++ b/mc_providers/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from .exceptions import UnknownProviderException, UnavailableProviderException, APIKeyRequired
 from .provider import ContentProvider
@@ -42,17 +42,19 @@ def available_provider_names() -> List[str]:
     return platforms
 
 
-def provider_by_name(name: str, api_key: str = None) -> ContentProvider:
+def provider_by_name(name: str, api_key: Optional[str], base_url: Optional[str]) -> ContentProvider:
     parts = name.split(NAME_SEPARATOR)
-    return provider_for(parts[0], parts[1], api_key)
+    return provider_for(parts[0], parts[1], api_key, base_url)
 
 
-def provider_for(platform: str, source: str, api_key: str = None) -> ContentProvider:
+def provider_for(platform: str, source: str, api_key: Optional[str], base_url: Optional[str]) -> ContentProvider:
     """
     A factory method that returns the appropriate data provider. Throws an exception to let you know if the
     arguments are unsupported.
     :param platform: One of the PLATFORM_* constants above.
     :param source: One of the PLATFORM_SOURCE>* constants above.
+    :param api_key: The API key needed to access the provider.
+    :param base_url: For custom integrations you can provide an alternate base URL for the provider's API server
     :return:
     """
     available = available_provider_names()
@@ -73,10 +75,10 @@ def provider_for(platform: str, source: str, api_key: str = None) -> ContentProv
             platform_provider = YouTubeYouTubeProvider(api_key)
         
         elif (platform == PLATFORM_ONLINE_NEWS) and (source == PLATFORM_SOURCE_WAYBACK_MACHINE):
-            platform_provider = OnlineNewsWaybackMachineProvider()
+            platform_provider = OnlineNewsWaybackMachineProvider(base_url)
 
         elif (platform == PLATFORM_ONLINE_NEWS) and (source == PLATFORM_SOURCE_MEDIA_CLOUD):
-            platform_provider = OnlineNewsMediaCloudProvider()
+            platform_provider = OnlineNewsMediaCloudProvider(base_url)
         
         elif (platform == PLATFORM_ONLINE_NEWS) and (source == PLATFORM_SOURCE_MEDIA_CLOUD_LEGACY):
             if api_key is None:

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from typing import List, Dict
+from typing import List, Dict, Optional
 import dateparser
 import hashlib
 import logging
@@ -23,11 +23,11 @@ class OnlineNewsAbstractProvider(ContentProvider):
     
     MAX_QUERY_LENGTH = pow(2, 14)
 
-    def __init__(self):
+    def __init__(self, base_url: Optional[str]):
         super().__init__()
-        self._client = self.get_client()
         self._logger = logging.getLogger(__name__)
-
+        self._base_url = base_url
+        self._client = self.get_client()
 
     def get_client(self):
         raise NotImplementedError("Abstract provider class should not be implimented directly")
@@ -295,11 +295,11 @@ class OnlineNewsWaybackMachineProvider(OnlineNewsAbstractProvider):
     All these endpoints accept a `domains: List[str]` keyword arg.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, base_url: Optional[str] = None):
+        super().__init__(base_url)
 
     def get_client(self):
-        return SearchApiClient("mediacloud")
+        return SearchApiClient("mediacloud", self._base_url)
 
     @classmethod
     def domain_search_string(cls):
@@ -334,15 +334,15 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
     All these endpoints accept a `domains: List[str]` keyword arg.
     For now we just use the wayback client, but eventually we'll have our own fork
     """
-    API_BASE_URL = "https://news-search-api.tarbell.mediacloud.org/v1/"
+    DEFAULT_API_BASE_URL = "https://news-search-api.mediacloud.org/v1/"
     DEFAULT_COLLECTION = "mediacloud_search_text_*"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, base_url=Optional[str]):
+        super().__init__(base_url)
 
     def get_client(self):
         #This seems cleaner than having a whole parallel client library
-        api_client = SearchApiClient(collection=self.DEFAULT_COLLECTION, api_base_url=self.API_BASE_URL)
+        api_client = SearchApiClient(collection=self.DEFAULT_COLLECTION, api_base_url=self._base_url)
         return api_client
 
     @classmethod

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Dict
+from typing import List, Dict, Optional
 import datetime as dt
 import datetime
 from operator import itemgetter
@@ -57,9 +57,9 @@ class ContentProvider(ABC):
         raise NotImplementedError("Doesn't support fetching all matching content.")
 
     def paged_items(self, query: str, start_date: dt.datetime, end_date: dt.datetime, page_size: int = 1000,
-                    **kwargs):
-        # return just one page of items; implementing subclasses should read in token, offset, or whatever
-        # else they need from `kwargs` to determine which page to return
+                    **kwargs) -> tuple[List[Dict], Optional[str]]:
+        # return just one page of items and a pagination token to get next page; implementing subclasses
+        # should read in token, offset, or whatever else they need from `kwargs` to determine which page to return
         raise NotImplementedError("Doesn't support fetching all matching content.")
 
     def normalized_count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime,

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -4,11 +4,8 @@ import itertools
 import random
 import copy
 import mediacloud.api
-import mediacloud_legacy.api
-import mediacloud_legacy.tags
 import os
-from ..onlinenews import OnlineNewsWaybackMachineProvider, OnlineNewsMediaCloudProvider,\
-    OnlineNewsMediaCloudLegacyProvider
+from ..onlinenews import OnlineNewsWaybackMachineProvider, OnlineNewsMediaCloudProvider
 
 LEGACY_MEDIA_CLOUD_API_KEY = os.getenv('LEGACY_MEDIA_CLOUD_API_KEY', None)
 MEDIA_CLOUD_API_KEY = os.getenv('MEDIA_CLOUD_API_KEY', None)
@@ -227,16 +224,15 @@ class OnlineNewsWaybackMachineProviderTest(unittest.TestCase):
         assert True
     
     def test_overlarge_count_over_time(self):
-        base_query = "technology"
-        startdate = dt.datetime(2023, 11, 1)
-        enddate = dt.datetime(2023, 12, 1)
+        startdate = dt.datetime(2023, 12, 1)
+        enddate = dt.datetime(2023, 12, 3)
 
-        results = self._provider.count_over_time(base_query, startdate, enddate, domains=self.DOMAINS_OVER_LIMIT)
+        results = self._provider.count_over_time('*', startdate, enddate, domains=self.DOMAINS_OVER_LIMIT)
         
-        assert len(results["counts"]) == 31
+        assert len(results["counts"]) == 3
         
-        results_shuffled = self._provider.count_over_time(base_query, startdate, enddate, domains=self.DOL_SHUFFLED())
-        assert len(results_shuffled["counts"]) == 31 
+        results_shuffled = self._provider.count_over_time('*', startdate, enddate, domains=self.DOL_SHUFFLED())
+        assert len(results_shuffled["counts"]) == 3
         
         r_counts = [r["count"] for r in results["counts"]]
         shuffled_counts = [r["count"] for r in results_shuffled["counts"]]
@@ -245,14 +241,13 @@ class OnlineNewsWaybackMachineProviderTest(unittest.TestCase):
         assert results_shuffled == results 
         
     def test_overlarge_count(self):
-        base_query = "technology"
         startdate = dt.datetime(2023, 1, 1)
         enddate = dt.datetime(2023, 12, 1)
 
-        results = self._provider.count(base_query, startdate, enddate, domains=self.DOMAINS_OVER_LIMIT)
+        results = self._provider.count('*', startdate, enddate, domains=self.DOMAINS_OVER_LIMIT)
         assert results > 20000
         
-        results_shuffled = self._provider.count(base_query, startdate, enddate, domains=self.DOL_SHUFFLED())
+        results_shuffled = self._provider.count('*', startdate, enddate, domains=self.DOL_SHUFFLED())
         assert results_shuffled == results
 
     def test_overlarge_sample(self):
@@ -372,8 +367,7 @@ class OnlineNewsMediaCloudLegacyProviderTest(unittest.TestCase):
 class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
 
     def setUp(self):
-        self._provider = OnlineNewsMediaCloudProvider()
-        #self._provider._client.API_BASE_URL = "http://localhost:8020/v1/"
+        self._provider = OnlineNewsMediaCloudProvider("http://localhost:8010/v1/")
 
     def test_expanded_story_list(self):
         query = "*"


### PR DESCRIPTION
Integrate by passing in a new string param to `provider_by_name` or `provider_for`. Going to merge ASAP to keep integration testing going.