### PR TITLE
Support no chunking on MC

### DIFF
--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -97,7 +97,8 @@ class OnlineNewsAbstractProvider(ContentProvider):
         This kwargs should include `pagination_token`, which will get relayed in to the api client and fetch
         the right page of results.
         """
-        query = self._assemble_and_chunk_query_str(query, chunk=False, **kwargs)[0]
+        updated_kwargs = {**kwargs, 'chunk': False}
+        query = self._assemble_and_chunk_query_str(query, **updated_kwargs)[0]
         page, pagination_token = self._client.paged_articles(query, start_date, end_date, **kwargs)
         return self._matches_to_rows(page), pagination_token
 

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -381,7 +381,7 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         query = "*"
         start_date = dt.datetime(2020, 1, 1)
         end_date = dt.datetime(2023, 12, 1)
-        page1, next_token1 = self._provider.paged_items(query, start_date, end_date, expanded=True)
+        page1, next_token1 = self._provider.paged_items(query, start_date, end_date, expanded=True, chunk=False)
         assert len(page1) > 0
         for story in page1:
             assert "id" in story
@@ -392,7 +392,7 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         query = "biden"
         start_date = dt.datetime(2023, 11, 25)
         end_date = dt.datetime(2023, 11, 26)
-        page1, next_token1 = self._provider.paged_items(query, start_date, end_date)
+        page1, next_token1 = self._provider.paged_items(query, start_date, end_date, chunk=False)
         for story in page1:
             assert "publish_date" in story
             assert story['publish_date'] is not None
@@ -405,16 +405,17 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         query = "biden"
         start_date = dt.datetime(2020, 1, 1)
         end_date = dt.datetime(2023, 12, 1)
-        story_count = self._provider.count(query, start_date, end_date)
+        story_count = self._provider.count(query, start_date, end_date, chunk=False)
         # make sure test case is reasonable size (ie. more than one page, but not too many pages
         assert story_count > 1000
         # fetch first page
-        page1, next_token1 = self._provider.paged_items(query, start_date, end_date)
+        page1, next_token1 = self._provider.paged_items(query, start_date, end_date, chunk=False)
         assert len(page1) > 0
         assert next_token1 is not None
         page1_url1 = page1[0]['url']
         # grab token, fetch next page
-        page2, next_token2 = self._provider.paged_items(query, start_date, end_date, pagination_token=next_token1)
+        page2, next_token2 = self._provider.paged_items(query, start_date, end_date, chunk=False,
+                                                        pagination_token=next_token1)
         assert len(page2) > 0
         assert next_token2 is not None
         assert next_token1 != next_token2  # verify paging token changed
@@ -425,7 +426,7 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         query = "biden"
         start_date = dt.datetime(2023, 11, 1)
         end_date = dt.datetime(2023, 12, 1)
-        page1, _ = self._provider.paged_items(query, start_date, end_date, domains=domains)
+        page1, _ = self._provider.paged_items(query, start_date, end_date, domains=domains, chunk=False)
         assert len(page1) > 0
         for story in page1:
             assert "url" in story


### PR DESCRIPTION
One small wrinkle I missed (#22 and mediacloud/web-search#602) on the removal of chunking from Media Cloud. Paging already forced non-chunked, so if the user passes in a `chunk=False` indication this throws and error saying the `chunk` arg is specified twice. This more safely sets `chunk` so it supports the user overriding on the paging call.

(updated local tests against prod index via VPN pass, I'm going to go ahead and merge to push out the fix on prod so that the fix I want for feminicides can go out)