### PR TITLE
Add optional caching argument to Provider creation

### DIFF
--- a/mc_providers/__init__.py
+++ b/mc_providers/__init__.py
@@ -47,13 +47,15 @@ def available_provider_names() -> List[str]:
     ]
 
 
-def provider_by_name(name: str, api_key: Optional[str], base_url: Optional[str], caching: Optional[bool] = True) -> ContentProvider:
+def provider_by_name(name: str, api_key: Optional[str], base_url: Optional[str],
+                     timeout: Optional[int] = None,
+                     caching: bool = True) -> ContentProvider:
     parts = name.split(NAME_SEPARATOR)
-    return provider_for(parts[0], parts[1], api_key, base_url, caching=caching)
+    return provider_for(parts[0], parts[1], api_key, base_url, timeout=timeout, caching=caching)
 
 
 def provider_for(platform: str, source: str, api_key: Optional[str], base_url: Optional[str],
-                 timeout: Optional[int] = None, caching: Optional[bool] = True) -> ContentProvider:
+                 timeout: Optional[int] = None, caching: bool = True) -> ContentProvider:
     """
     A factory method that returns the appropriate data provider. Throws an exception to let you know if the
     arguments are unsupported.
@@ -66,8 +68,6 @@ def provider_for(platform: str, source: str, api_key: Optional[str], base_url: O
     """
     if timeout is None:
         timeout = DEFAULT_TIMEOUT
-    if caching is None:
-        caching = True
     available = available_provider_names()
     platform_provider: ContentProvider
     if provider_name(platform, source) in available:

--- a/mc_providers/__init__.py
+++ b/mc_providers/__init__.py
@@ -47,13 +47,13 @@ def available_provider_names() -> List[str]:
     ]
 
 
-def provider_by_name(name: str, api_key: Optional[str], base_url: Optional[str]) -> ContentProvider:
+def provider_by_name(name: str, api_key: Optional[str], base_url: Optional[str], caching: Optional[bool] = True) -> ContentProvider:
     parts = name.split(NAME_SEPARATOR)
-    return provider_for(parts[0], parts[1], api_key, base_url)
+    return provider_for(parts[0], parts[1], api_key, base_url, caching=caching)
 
 
 def provider_for(platform: str, source: str, api_key: Optional[str], base_url: Optional[str],
-                 timeout: int = None) -> ContentProvider:
+                 timeout: Optional[int] = None, caching: Optional[bool] = True) -> ContentProvider:
     """
     A factory method that returns the appropriate data provider. Throws an exception to let you know if the
     arguments are unsupported.
@@ -66,32 +66,35 @@ def provider_for(platform: str, source: str, api_key: Optional[str], base_url: O
     """
     if timeout is None:
         timeout = DEFAULT_TIMEOUT
+    if caching is None:
+        caching = True
     available = available_provider_names()
+    platform_provider: ContentProvider
     if provider_name(platform, source) in available:
         if (platform == PLATFORM_TWITTER) and (source == PLATFORM_SOURCE_TWITTER):
             if api_key is None:
                 raise APIKeyRequired(platform)
-                
-            platform_provider = TwitterTwitterProvider(api_key, timeout)
-            
+
+            platform_provider = TwitterTwitterProvider(api_key, timeout, caching)
+
         elif (platform == PLATFORM_REDDIT) and (source == PLATFORM_SOURCE_PUSHSHIFT):
-            platform_provider = RedditPushshiftProvider(timeout)
-        
+            platform_provider = RedditPushshiftProvider(timeout, caching)
+
         elif (platform == PLATFORM_YOUTUBE) and (source == PLATFORM_SOURCE_YOUTUBE):
             if api_key is None:
                 raise APIKeyRequired(platform)
-                
-            platform_provider = YouTubeYouTubeProvider(api_key, timeout)
+
+            platform_provider = YouTubeYouTubeProvider(api_key, timeout, caching)
         
         elif (platform == PLATFORM_ONLINE_NEWS) and (source == PLATFORM_SOURCE_WAYBACK_MACHINE):
-            platform_provider = OnlineNewsWaybackMachineProvider(base_url, timeout)
+            platform_provider = OnlineNewsWaybackMachineProvider(base_url, timeout, caching)
 
         elif (platform == PLATFORM_ONLINE_NEWS) and (source == PLATFORM_SOURCE_MEDIA_CLOUD):
-            platform_provider = OnlineNewsMediaCloudProvider(base_url, timeout)
+            platform_provider = OnlineNewsMediaCloudProvider(base_url, timeout, caching)
 
         else:
             raise UnknownProviderException(platform, source)
-        
+
         return platform_provider
     else:
         raise UnavailableProviderException(platform, source)

--- a/mc_providers/cache.py
+++ b/mc_providers/cache.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional
+from typing import Callable, Iterable, Optional
 
 from .provider import ContentProvider
 
@@ -13,18 +13,26 @@ class CachingManager():
     cache_function = None
 
     @classmethod
-    def cache(cls, custom_prefix_for_key: Optional[str] = None):
+    def cache(cls, custom_prefix_for_key: Optional[str] = None, kwargs_to_ignore: Iterable[str] = []):
         """
         @param custom_prefix_for_key: if specified, will be used in place of function name for cache_key generation
         """
         def decorator(fn: Callable):
+            # WISH: detect if 'fn' is being declared as a method to a ContentProvider!!
             def wrapper(*args, **kwargs):
-                cache_prefix = custom_prefix_for_key if custom_prefix_for_key is not None else fn.__name__
-                # see if first argument is a ContentProvider (invocation of ContentProvider method)
-                # this could be less ugly if "cache" was ONLY EVER used on ContentProvider methods!
-                caching = len(args) < 1 or not isinstance(args[0], ContentProivider) or args[0]._caching
-                if caching and cls.cache_function is not None:
-                    # use the function name
+                # blindly assume that everything decorated is a ContentProvider method!
+                inst = args[0]
+                assert isinstance(inst, ContentProvider)
+                # check caching enabled and wasn't disabled when Provider instantiated
+                if cls.cache_function is not None and inst._caching:
+                    cache_prefix = custom_prefix_for_key or fn.__name__
+                    # remove any kwargs already processed
+                    # and included in positional args (ie; query string)
+                    if kwargs_to_ignore and kwargs:
+                        kwargs = kwargs.copy()
+                        for kw in kwargs_to_ignore:
+                            if kw in kwargs:
+                                kwargs.pop(kw)
                     results, was_cached = cls.cache_function(fn, cache_prefix, *args, **kwargs)
                     return results
                 else:

--- a/mc_providers/cache.py
+++ b/mc_providers/cache.py
@@ -1,5 +1,6 @@
 from typing import Callable, Optional
 
+from .provider import ContentProvider
 
 class CachingManager():
     """
@@ -19,7 +20,10 @@ class CachingManager():
         def decorator(fn: Callable):
             def wrapper(*args, **kwargs):
                 cache_prefix = custom_prefix_for_key if custom_prefix_for_key is not None else fn.__name__
-                if cls.cache_function is not None:
+                # see if first argument is a ContentProvider (invocation of ContentProvider method)
+                # this could be less ugly if "cache" was ONLY EVER used on ContentProvider methods!
+                caching = len(args) < 1 or not isinstance(args[0], ContentProivider) or args[0]._caching
+                if caching and cls.cache_function is not None:
                     # use the function name
                     results, was_cached = cls.cache_function(fn, cache_prefix, *args, **kwargs)
                     return results

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -20,8 +20,8 @@ class OnlineNewsAbstractProvider(ContentProvider):
     
     MAX_QUERY_LENGTH = pow(2, 14)
 
-    def __init__(self, base_url: Optional[str], timeout: int = None):
-        super().__init__()
+    def __init__(self, base_url: Optional[str], timeout: int = None, caching: bool = True):
+        super().__init__(caching)
         self._logger = logging.getLogger(__name__)
         self._base_url = base_url
         self._timeout = timeout
@@ -60,7 +60,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
 
     # Chunk'd
     def count_over_time(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> Dict:
-        counter = Counter()
+        counter: Counter = Counter()
         for subquery in self._assemble_and_chunk_query_str(query, **kwargs):
             results = self._client.count_over_time(subquery, start_date, end_date, **kwargs)
             countable = {i['date']: i['count'] for i in results}
@@ -120,7 +120,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
         sample_size = 5000
         
         # An accumulator for the subqueries
-        results_counter = Counter({})
+        results_counter: Counter = Counter({})
         for subquery in chunked_queries:
             this_results = self._client.terms(subquery, start_date, end_date,
                                      self._client.TERM_FIELD_TITLE, self._client.TERM_AGGREGATION_TOP)
@@ -142,7 +142,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
         
         matching_count = self.count(query, start_date, end_date, **kwargs)
 
-        results_counter = Counter({})
+        results_counter: Counter = Counter({})
         for subquery in self._assemble_and_chunk_query_str(query, **kwargs) :   
             this_languages = self._client.top_languages(subquery, start_date, end_date, **kwargs)
             countable = {item["name"]: item["value"] for item in this_languages}
@@ -166,7 +166,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
         
         # all_results = []
         
-        results_counter = Counter({})
+        results_counter: Counter = Counter({})
         for subquery in self._assemble_and_chunk_query_str(query, **kwargs):
             results = self._client.top_sources(subquery, start_date, end_date)
             countable = {source['name']: source['value'] for source in results}
@@ -285,8 +285,8 @@ class OnlineNewsWaybackMachineProvider(OnlineNewsAbstractProvider):
     All these endpoints accept a `domains: List[str]` keyword arg.
     """
 
-    def __init__(self, base_url: Optional[str] = None, timeout: int = None):
-        super().__init__(base_url, timeout)  # will call get_client
+    def __init__(self, base_url: Optional[str] = None, timeout: int = None, caching: bool = True):
+        super().__init__(base_url, timeout, caching)  # will call get_client
 
     def get_client(self):
         client = SearchApiClient("mediacloud", self._base_url)
@@ -329,8 +329,8 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
     
     DEFAULT_COLLECTION = "mc_search-*"
 
-    def __init__(self, base_url=Optional[str], timeout: int = None):
-        super().__init__(base_url, timeout)
+    def __init__(self, base_url=Optional[str], timeout: int = None, caching: bool = True):
+        super().__init__(base_url, timeout, caching)
 
     def get_client(self):
         api_client = MCSearchApiClient(collection=self.DEFAULT_COLLECTION, api_base_url=self._base_url)

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -20,7 +20,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
     
     MAX_QUERY_LENGTH = pow(2, 14)
 
-    def __init__(self, base_url: Optional[str], timeout: int = None, caching: bool = True):
+    def __init__(self, base_url: Optional[str], timeout: Optional[int] = None, caching: bool = True):
         super().__init__(caching)
         self._logger = logging.getLogger(__name__)
         self._base_url = base_url
@@ -101,7 +101,6 @@ class OnlineNewsAbstractProvider(ContentProvider):
     @CachingManager.cache()
     def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
               **kwargs) -> List[Dict]:
-        
         chunked_queries = self._assemble_and_chunk_query_str(query, **kwargs)
 
         # first figure out the dominant languages, so we can remove appropriate stopwords.
@@ -193,7 +192,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
         domains = kwargs.get('domains', [])
 
         filters = kwargs.get('filters', [])
-        
+
         if chunk and (len(base_query) > cls.MAX_QUERY_LENGTH):
             # of course there still is the possibility that the base query is too large, which
             # cannot be fixed by this method
@@ -240,31 +239,27 @@ class OnlineNewsAbstractProvider(ContentProvider):
     
     @classmethod
     def _assembled_query_str(cls, query: str, **kwargs) -> str:
-        
+        # filter and/or domain clauses (selectors to be OR'ed together)
+        selector_clauses = []
+
         domains = kwargs.get('domains', [])
-        domain_clause = ""
-        
         if len(domains) > 0:
             domain_string = " OR ".join(domains)
-            domain_clause = f"{cls.domain_search_string()}:({domain_string})"
+            selector_clauses.append(f"{cls.domain_search_string()}:({domain_string})")
             
+        # put all filters in single query string
         filters = kwargs.get('filters', [])
-        filter_clause = ""
-        
         if len(filters) > 0:
-            filter_clause = " OR ".join(filters)
-        
-        # need to put all those filters in single query string
-        q = query
-        
-        if (len(domains) > 0) and (len(filters) > 0) :
-            q += f" AND (({domain_clause}) OR ({filter_clause}))"
-        
-        elif len(domains) > 0:
-            q += f" AND ({domain_clause})"
-        
-        elif len(filters) > 0:
-            q += f" AND ({filter_clause})"
+            selector_clauses.append(" OR ".join(filters))
+
+        if len(selector_clauses) > 0:
+            # generalized to any number of clauses (keep an open mind about sanity clause)
+            # Add parens around user query and each clause to defend ORs
+            # against grabby ANDs:
+            clauses_string = " OR ".join([f"({clause})" for clause in selector_clauses])
+            q = f"({query}) AND ({clauses_string})"
+        else:
+            q = query
         return q
 
     @classmethod
@@ -285,7 +280,7 @@ class OnlineNewsWaybackMachineProvider(OnlineNewsAbstractProvider):
     All these endpoints accept a `domains: List[str]` keyword arg.
     """
 
-    def __init__(self, base_url: Optional[str] = None, timeout: int = None, caching: bool = True):
+    def __init__(self, base_url: Optional[str] = None, timeout: Optional[int] = None, caching: bool = True):
         super().__init__(base_url, timeout, caching)  # will call get_client
 
     def get_client(self):
@@ -329,7 +324,7 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
     
     DEFAULT_COLLECTION = "mc_search-*"
 
-    def __init__(self, base_url=Optional[str], timeout: int = None, caching: bool = True):
+    def __init__(self, base_url=Optional[str], timeout: Optional[int] = None, caching: bool = True):
         super().__init__(base_url, timeout, caching)
 
     def get_client(self):
@@ -377,6 +372,7 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
         # no chunking on MC
         q = self._assembled_query_str(query, **kwargs)
         results = self._overview_query(q, start_date, end_date, **kwargs)
+        to_return: List[Dict]
         if self._client._is_no_results(results):
             to_return = []
         else:
@@ -393,7 +389,8 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
         sorted_results = sorted(to_return, key=lambda x: x["timestamp"])
         return {'counts': sorted_results}
 
-    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> List[Dict]:
+    # NB: limit argument ignored, but included to keep mypy quiet
+    def sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 20, **kwargs) -> List[Dict]:
         # no chunking on MC
         q = self._assembled_query_str(query, **kwargs)
         results = self._overview_query(q, start_date, end_date, **kwargs)
@@ -427,7 +424,9 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
         cleaned_sources = sorted(cleaned_sources, key=lambda x: x['count'], reverse=True)
         return cleaned_sources
 
-    @CachingManager.cache('overview')
+    # query string contains domains/filters at this point
+    @CachingManager.cache('overview', ['domains', 'filters'])
     def _overview_query(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs) -> Dict:
         q = self._assembled_query_str(query, **kwargs)
+
         return self._client._overview_query(q, start_date, end_date, **kwargs)

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -21,8 +21,11 @@ class ContentProvider(ABC):
     Any unimplemented methods raise an Exception
     """
 
-    def __init__(self):
+    def __init__(self, caching: Optional[bool] = True):
         self._logger = logging.getLogger(__name__)
+        if caching is None:
+            caching = True
+        self._caching = caching
 
     def everything_query(self) -> str:
         raise QueryingEverythingUnsupportedQuery()
@@ -114,7 +117,7 @@ class ContentProvider(ABC):
         sample_size = kwargs['sample_size'] if 'sample_size' in kwargs else DEFAULT_LANGUAGE_SAMPLE
         # grab a sample and count terms as we page through it
         sampled_count = 0
-        counts = collections.Counter()
+        counts: collections.Counter = collections.Counter()
         for page in self.all_items(query, start_date, end_date, limit=sample_size):
             sampled_count += len(page)
             [counts.update(t['language'] for t in page)]
@@ -129,7 +132,7 @@ class ContentProvider(ABC):
         sample_size = kwargs['sample_size'] if 'sample_size' in kwargs else DEFAULT_WORDS_SAMPLE
         # grab a sample and count terms as we page through it
         sampled_count = 0
-        counts = collections.Counter()
+        counts: collections.Counter = collections.Counter()
         for page in self.all_items(query, start_date, end_date, limit=sample_size):
             sampled_count += len(page)
             [counts.update(terms_without_stopwords(t['language'], t['title'])) for t in page]

--- a/mc_providers/reddit.py
+++ b/mc_providers/reddit.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import datetime as dt
 import requests
-from typing import List, Dict
+from typing import List, Dict, Optional
 import logging
 
 from .errors import deprecated
@@ -17,8 +17,8 @@ DEFAULT_TIMEOUT = 60
 @deprecated
 class RedditPushshiftProvider(ContentProvider):
 
-    def __init__(self, timeout: int = None):
-        super(RedditPushshiftProvider, self).__init__()
+    def __init__(self, timeout: int = None, caching: Optional[bool] = True):
+        super(RedditPushshiftProvider, self).__init__(caching)
         self._logger = logging.getLogger(__name__)
         self._session = requests.Session()  # better performance to put all HTTP through this one object
         self._timeout = timeout or DEFAULT_TIMEOUT

--- a/mc_providers/twitter.py
+++ b/mc_providers/twitter.py
@@ -27,8 +27,8 @@ class TwitterTwitterProvider(ContentProvider):
     MAX_QUERY_LENGTH = 1024  # I think?
     POLITENESS_DELAY = 1  # sleep for half a second if we're gonna spam a bunch of queries
     
-    def __init__(self, bearer_token=None, timeout=None):
-        super(TwitterTwitterProvider, self).__init__()
+    def __init__(self, bearer_token=None, timeout=None, caching=True):
+        super(TwitterTwitterProvider, self).__init__(caching)
         self._logger = logging.getLogger(__name__)
         self._bearer_token = bearer_token
         self._session = requests.Session()  # better performance to put all HTTP through this one object
@@ -129,7 +129,7 @@ class TwitterTwitterProvider(ContentProvider):
         :param kwargs:
         :return:
         """
-        counter = Counter()
+        counter: Counter = Counter()
 
         for subquery in  self._assemble_and_chunk_query_str(query, **kwargs):
             #print(subquery)

--- a/mc_providers/youtube.py
+++ b/mc_providers/youtube.py
@@ -27,8 +27,8 @@ class YouTubeYouTubeProvider(ContentProvider):
     Get matching YouTube videos
     """
 
-    def __init__(self, api_key: str, timeout: int = None):
-        super(YouTubeYouTubeProvider, self).__init__()
+    def __init__(self, api_key: str, timeout: int = None, caching: bool = True):
+        super(YouTubeYouTubeProvider, self).__init__(caching)
         self._logger = logging.getLogger(__name__)
         self._api_key = api_key
         self._timeout = timeout or DEFAULT_TIMEOUT


### PR DESCRIPTION
I wanted to see how hard it would be to allow cache avoidance, and this is what happened.

I used mypy to check my code, so I tried to quiet it down (in default/basic mode) and tried to get the complaints about onlinenews.py down.

mcweb is still wrapping all user queries in parens, and wanted to see if I could make sure that wasn't needed.  This resulted in changes to the overview query method, including changes to omit duplicate information from the cache key, and to allow three flavors of story selectors.

Questions/thoughts:
I naively expected a filters argument to be subtractive (ANDed to limit stories scanned), but it seems that filters and domains are additive (ORed to increase stories scanned)!

As it stands, a checkbox (or global option) in mcweb will be kinda miserable, since the code runs the same basic "overview" query for multiple methods, with different post-processing for the results.

[removed a paragraph here, 'cause I realized it doesn't make sense]