### PR TITLE
Remove doubled calls to _assembled_query_str in OnlineNewsMediaCloudProvider

### DIFF
--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -410,7 +410,6 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
     def languages(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 10,
                   **kwargs) -> List[Dict]:
         logger.debug("MC.languages %s %s %s %r", query, start_date, end_date, kwargs)
-        q = self._assembled_query_str(query, **kwargs)
         results = self._overview_query(query, start_date, end_date, **kwargs)
         if self._client._is_no_results(results):
             return []


### PR DESCRIPTION
Also add debug logging thruout OnlineNewsMediaCloudProvider and a little bit in mediacloud.py

fixes https://github.com/mediacloud/mc-providers/issues/34 (see below for before/after logging)
fixes https://github.com/mediacloud/mc-providers/issues/35 (in PART)

NOTE: was not able to run `pytest`

test program:
```
q = 'government'
start_date = dt.date(2024,7,1)
end_date = dt.date(2024,8,1)
domains = ["nytimes.com"]
print(prov.count(q, start_date, end_date, domains=domains))
```

BEFORE (note domain appears twice):

```
DEBUG:mc_providers.onlinenews:MC.count government 2024-07-01 2024-08-01 {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:_assembled_query_str IN: government {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:_assembled_query_str OUT: (government) AND ((canonical_domain:(nytimes.com)))
DEBUG:mc_providers.onlinenews:MC._overview (government) AND ((canonical_domain:(nytimes.com))) 2024-07-01 2024-08-01 {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:_assembled_query_str IN: (government) AND ((canonical_domain:(nytimes.com))) {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:_assembled_query_str OUT: ((government) AND ((canonical_domain:(nytimes.com)))) AND ((canonical_domain:(nytimes.com)))
```

AFTER (with even more debugging):

```
DEBUG:mc_providers.onlinenews:MC.count government 2024-07-01 2024-08-01 {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:MC._overview government 2024-07-01 2024-08-01 {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:_assembled_query_str IN: government {'domains': ['nytimes.com']}
DEBUG:mc_providers.onlinenews:_assembled_query_str OUT: (government) AND ((canonical_domain:(nytimes.com)))
DEBUG:mc_providers.mediacloud:_overview IN: (government) AND ((canonical_domain:(nytimes.com))) 2024-07-01 2024-08-01 {'domains': ['nytimes.com']}
DEBUG:mc_providers.mediacloud:_overview params: {'q': '((government) AND ((canonical_domain:(nytimes.com)))) AND publication_date:[2024-07-01 TO 2024-08-01]', 'domains': ['nytimes.com']}
DEBUG:mc_providers.mediacloud:_query IN: POST ep mc_search-*/search/overview par {'q': '((government) AND ((canonical_domain:(nytimes.com)))) AND publication_date:[2024-07-01 TO 2024-08-01]', 'domains': ['nytimes.com']}
DEBUG:mc_providers.mediacloud:_query SENDING POST ep http://ramos.angwin:8000/v1/mc_search-*/search/overview par {'q': '((government) AND ((canonical_domain:(nytimes.com)))) AND publication_date:[2024-07-01 TO 2024-08-01]'}
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): ramos.angwin:8000
DEBUG:urllib3.connectionpool:http://ramos.angwin:8000 "POST /v1/mc_search-*/search/overview HTTP/11" 200 6239
DEBUG:mc_providers.onlinenews:MC.count: 1185
```