### PR TITLE
Fix MediaCloudESProvider to accept NSA sort parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Make sure `pip install flit twine` so you can build and deploy to PyPI.
 4. A github action will build and push the repository on committing a tagged version
 
 ### Version History
+* __v3.0.1__ - Fix ES Provider to accept sort_{order,field} paging arguments like NSA-based Provider
 * __v3.0.0__ - New "OnlineNewsMediaCloudProvider" using Elasticsearch DSL for direct access to the ES cluster. Retain old provider as "OnlineNewsMediaCloudOldProvider" for now. 
 * __v2.2.0__ - Added an optional argument to providers to toggle caching behavior, added more specific error on 504
 * __v2.1.1__ - Bugfix

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -659,12 +659,12 @@ _EMPTY_OVERVIEW = Overview(query="", total=-1, topdomains={}, toplangs={}, daily
 # Was publication_date, but web-search always passes indexed_date.
 # identical indexed_date values (without fractional seconds?!)  have
 # been seen in the wild (entire day 2024-01-10).
-_DEF_PAGE_SORT_FIELD = "indexed_date"
-_DEF_PAGE_SORT_ORDER = "desc"
+_DEF_SORT_FIELD = "indexed_date"
+_DEF_SORT_ORDER = "desc"
 
-# Secondary sort key to break ties if page_sort_field is non-empty.
-# Used as sole sort key if "page_sort_field" argument or
-# _DEF_PAGE_SORT_FIELD (above) is empty string.
+# Secondary sort key to break ties if sort_field is non-empty.
+# Used as sole sort key if "sort_field" argument or
+# _DEF_SORT_FIELD (above) is empty string.
 # _doc is documented as most efficient sort key at:
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html
 #
@@ -677,7 +677,7 @@ _DEF_PAGE_SORT_ORDER = "desc"
 #
 # HOWEVER: use of session_id/preference should route all requests
 # from the same session to the same shards for each successive query.
-_SECONDARY_PAGE_SORT_ARGS = {"_doc": "asc"}
+_SECONDARY_SORT_ARGS = {"_doc": "asc"}
 
 def _sanitize(s: str) -> str:
     """
@@ -1120,21 +1120,21 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
 
         page_size = min(page_size, _ES_MAXPAGE)
         expanded = kwargs.pop("expanded", False)
-        page_sort_field = kwargs.pop("page_sort_field", _DEF_PAGE_SORT_FIELD)
-        page_sort_order = kwargs.pop("page_sort_order", _DEF_PAGE_SORT_ORDER)
+        sort_field = kwargs.pop("sort_field", _DEF_SORT_FIELD)
+        sort_order = kwargs.pop("sort_order", _DEF_SORT_ORDER)
         pagination_token = kwargs.pop("pagination_token", None)
 
         # NOTE! depends on client limiting to reasonable choices!!
         # (full text might leak data, or causes memory exhaustion!)
-        if page_sort_field not in self._fields(expanded):
-            raise ValueError(page_sort_field)
-        if page_sort_order not in ["asc", "desc"]:
-            raise ValueError(page_sort_order)
+        if sort_field not in self._fields(expanded):
+            raise ValueError(sort_field)
+        if sort_order not in ["asc", "desc"]:
+            raise ValueError(sort_order)
 
-        # see discussion above at _SECONDARY_PAGE_SORT_ARGS declaration
+        # see discussion above at _SECONDARY_SORT_ARGS declaration
         sort_opts = [
-            {page_sort_field: page_sort_order},
-            _SECONDARY_PAGE_SORT_ARGS
+            {sort_field: sort_order},
+            _SECONDARY_SORT_ARGS
         ]
 
         search = self._basic_search(query, start_date, end_date, expanded=expanded, **kwargs)\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "mc-providers"
-version = "3.0.0"
+version = "3.0.1"
 authors = [
     {name = "Paige Gulley", email = "nano3.14@gmail.com"},
     {name = "Rahul Bhargava", email = "r.bhargava@northeastern.edu"},


### PR DESCRIPTION
Fix incompatibility with NSA based provider, seen in web-search CSV download