### PR TITLE
Add OnlineNewsMediaCloudESProvider.random_sample method & tests

### DIFF
--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -1269,7 +1269,7 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
 
         `kwargs` may contain: `sort_field` (str), `sort_order` (str)
         """
-        logger.debug("MCES._paged_articles q: %s: %s e: %s ps: %d",
+        logger.debug("MCES._paged_items q: %s: %s e: %s ps: %d",
                      query, start_date, end_date, page_size)
         self.trace(Trace.QSTR, "MCES._paged_items kw: %r", kwargs)
 

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -668,7 +668,7 @@ ES_Fieldname: TypeAlias = str | InstrumentedField # quiet mypy complaints
 ES_Fieldnames: TypeAlias = list[ES_Fieldname]
 
 class FilterTuple(NamedTuple):
-    weight: int | float
+    weight: int
     query: Query | None
 
 _ES_MAXPAGE = 1000              # define globally (ie; in .providers)???

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -4,7 +4,7 @@ import logging
 import os
 import random
 from collections import Counter
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, TypeAlias, TypedDict
+from typing import Any, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, TypeAlias, TypedDict
 
 # PyPI
 import ciso8601
@@ -662,7 +662,10 @@ from elasticsearch_dsl.utils import AttrDict
 from .exceptions import MysteryProviderException, ProviderParseException, PermanentProviderException, ProviderException, TemporaryProviderException
 
 Field: TypeAlias = str | InstrumentedField # quiet mypy complaints
-FilterTuple: TypeAlias = tuple[int, Query | None]
+
+class FilterTuple(NamedTuple):
+    weight: int
+    query: Query | None
 
 _ES_MAXPAGE = 1000              # define globally (ie; in .providers)???
 
@@ -878,10 +881,10 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
         selector_clauses = cls._selector_query_clauses(kwargs)
         if selector_clauses:
             sqs = cls._selector_query_string_from_clauses(selector_clauses)
-            return (cls._selector_count(kwargs) * cls.SELECTOR_WEIGHT,
-                    SanitizedQueryString(query=sqs))
+            return FilterTuple(cls._selector_count(kwargs) * cls.SELECTOR_WEIGHT,
+                               SanitizedQueryString(query=sqs))
         else:
-            return (0, None)
+            return FilterTuple(0, None)
 
     def _basic_search(self, user_query: str, start_date: dt.datetime, end_date: dt.datetime,
                      expanded: bool = False, source: bool = True, **kwargs: Any) -> Search:
@@ -925,17 +928,18 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
 
         days = (end_date - start_date).days + 1
         filters : list[FilterTuple] = [
-            (days * self.DAY_WEIGHT, Range(publication_date={'gte': start, "lte": end})),
+            FilterTuple(days * self.DAY_WEIGHT, Range(publication_date={'gte': start, "lte": end})),
             self._selector_filter_tuple(kwargs)
             # could include languages (etc) here
         ]
 
         # try applying more selective queries (fewer results) first
-        filters.sort()
-        for weight, query in filters:
-            if query:
+        # key function avoids attempts to compare Query objects when tied!
+        filters.sort(key=lambda ft : ft.weight)
+        for ft in filters:
+            if ft.query:
                 # ends up as list under bool.filter:
-                s = s.filter(query)
+                s = s.filter(ft.query)
 
         if source:              # return source (fields)?
             return s.source(self._fields(expanded))

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -1271,7 +1271,7 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
         """
         logger.debug("MCES._paged_articles q: %s: %s e: %s ps: %d",
                      query, start_date, end_date, page_size)
-        self.trace(Trace.QSTR, "MCES._paged_articles kw: %r", kwargs)
+        self.trace(Trace.QSTR, "MCES._paged_items kw: %r", kwargs)
 
         page_size = min(page_size, _ES_MAXPAGE)
         expanded = kwargs.pop("expanded", False)
@@ -1367,7 +1367,8 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
 
         To implement pagination in web-search API, would need to have
         a method here that takes and returns a pagination token that
-        this method calls...
+        this method calls...  Perhaps paged_items could do the job
+        when passed a "randomize" argument???
         """
         if not fields:
             # _COULD_ default to everything, but make user think

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -1410,19 +1410,9 @@ class OnlineNewsMediaCloudESProvider(OnlineNewsMediaCloudProvider):
         hits = self._search_hits(search)
         yield [self._hit_to_row(hit, fields) for hit in hits] # just one page
 
-    def _sample_titles(self, query: str, start_date: dt.datetime, end_date: dt.datetime, sample_size: int,
-                       **kwargs: Any) -> Iterable[list[dict[str,str]]]:
-        """
-        worker for Provider._sampled_title_words
-        (could be eliminated if _sampled_title_words calls random_sample?)
-        """
-        return self.random_sample(query, start_date, end_date, sample_size,
-                            fields=["title", "language"], **kwargs)
-
     def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
                              **kwargs: Any) -> list[Term]:
         """
-        uses generic Provider._sampled_title_words
-        with data from local helper above
+        uses generic Provider._sampled_title_words and Provider._sample_titles!
         """
         return self._sampled_title_words(query, start_date, end_date, limit=limit, **kwargs)

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -440,20 +440,20 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         # unfixed code died with "TypeError: '<' not supported between instances of 'SanitizedQueryString' and 'Range'"
         page1, _ = self._provider.paged_items(query, start_date, end_date, domains=domains, page_size=1)
 
-    def _collect_random_results(self, query, fields, limit, start, end):
+    def _collect_random_results(self, query, fields, page_size, start, end):
         start_date = start or dt.datetime(2023, 1, 1)
         end_date = end or dt.datetime(2023, 12, 31)
         results = []
         # currently returns only one page, but be prepared!
         for page in self._provider.random_sample(query, start_date, end_date,
-                                                 limit=limit, fields=fields):
+                                                 page_size=page_size, fields=fields):
             results.extend(page)
         return results
 
-    def _test_random_sample(self, fields, limit, start=None, end=None):
-        # check limit filled
-        results = self._collect_random_results("biden", fields, limit, start, end)
-        assert len(results) == limit
+    def _test_random_sample(self, fields, page_size, start=None, end=None):
+        # check page_size filled
+        results = self._collect_random_results("biden", fields, page_size, start, end)
+        assert len(results) == page_size
 
         fset = set(fields)
         for item in results:
@@ -486,7 +486,7 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
     def test_random_sample_all(self):
         self._test_random_sample(["id", "indexed_date", "language",
                                   "media_name", "media_url", "publish_date",
-                                  "text", "title", "url"], limit=2)
+                                  "text", "title", "url"], page_size=2)
 
 @pytest.mark.skipif(IN_GITHUB_CI_WORKFLOW, reason="requires VPN tunnel to Media Cloud News Search API server")
 class OnlineNewsMediaCloudOldProviderTest(OnlineNewsWaybackMachineProviderTest):

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -428,6 +428,17 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         assert story['language'] == 'en'
         assert story['media_name'] == 'cnn.com'
 
+    def test_equal_weight(self):
+        # assumes equal weights: could construct arguments (for integer weights)
+        domains = ["nytimes.com"]
+        days = 1
+        assert (len(domains) * self._provider.SELECTOR_WEIGHT == days * self._provider.DAY_WEIGHT)
+        query = "biden"
+        start_date = dt.datetime(2024, 12, 1)
+        end_date = start_date + dt.timedelta(days=days-1)
+        breakpoint()
+        # unfixed code died with "TypeError: '<' not supported between instances of 'SanitizedQueryString' and 'Range'"
+        page1, _ = self._provider.paged_items(query, start_date, end_date, domains=domains, page_size=1)
 
 
 @pytest.mark.skipif(IN_GITHUB_CI_WORKFLOW, reason="requires VPN tunnel to Media Cloud News Search API server")


### PR DESCRIPTION
First draft, for your consideration...

Adds a new random_sample method (by extending the existing code used to sample titles) with a required fields=["field1", "field2"] which determines the fields returned.

I could almost certainly tuck the functionality into the existing `sample` method if the fields argument isn't passed, call `super().sample(....)` which will return the (possibly not so random) `hits` from the overview query.

Then, if web-search passed a fields list in the `/api/search/sample` endpoint the new (separate) query would be used for the sample stories for a search...