### PR TITLE
Fix bug when number of days and number of sources have equal weighted values

### DIFF
--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -436,7 +436,6 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         query = "biden"
         start_date = dt.datetime(2024, 12, 1)
         end_date = start_date + dt.timedelta(days=days-1)
-        breakpoint()
         # unfixed code died with "TypeError: '<' not supported between instances of 'SanitizedQueryString' and 'Range'"
         page1, _ = self._provider.paged_items(query, start_date, end_date, domains=domains, page_size=1)
 

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -428,6 +428,17 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         assert story['language'] == 'en'
         assert story['media_name'] == 'cnn.com'
 
+    def test_equal_weight(self):
+        # assumes equal weights: could construct arguments (for integer weights)
+        domains = ["nytimes.com"]
+        days = 1
+        assert (len(domains) * self._provider.SELECTOR_WEIGHT == days * self._provider.DAY_WEIGHT)
+        query = "biden"
+        start_date = dt.datetime(2024, 12, 1)
+        end_date = start_date + dt.timedelta(days=days-1)
+        breakpoint()
+        # unfixed code died with "TypeError: '<' not supported between instances of 'SanitizedQueryString' and 'Range'"
+        page1, _ = self._provider.paged_items(query, start_date, end_date, domains=domains, page_size=1)
 
 
 @pytest.mark.skipif(IN_GITHUB_CI_WORKFLOW, reason="requires VPN tunnel to Media Cloud News Search API server")


### PR DESCRIPTION
* Make FilterTuple a NamedTuple, provide key function for sort
* Includes test

Fixes problem seen in wild: https://meag.sentry.io/issues/6273067280/?project=6781815&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=17