### PR TITLE
Use spacy for termification, return document counts/ratios

### DIFF
--- a/mc_providers/language/__init__.py
+++ b/mc_providers/language/__init__.py
@@ -1,8 +1,12 @@
-import fasttext
-from typing import List
+import logging
 import os
 import re
-import logging
+from collections import Counter
+from typing import List
+
+# PyPI
+import fasttext
+import spacy
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +21,8 @@ _stopwords_by_language = {}
 
 fasttext_model = None
 
+# XXX possibly tell spacy what NOT to load?
+# https://spacy.io/usage/processing-pipelines#disabling
 
 def _get_model():
     try:
@@ -54,28 +60,54 @@ def stopwords_for_language(lang_code: str) -> set:
                                                  if not line.startswith('#') and len(line) > 0)
     return _stopwords_by_language[lang_code]
 
-# match all non-word and non-space characters: almost CERTAINLY too agressive!
-# maybe just quotes, parens, braces etc (but there are lots of them in unicode!)?
-PUNCTUATION_RE = re.compile(r'[^\w\s]')
 
-def terms_without_stopwords(lang_code: str, text: str, remove_punctuation: bool = True) -> List[str]:
+_IGNORE_BY_LANG = {
+    "en": set(["'s"]),
+}
+_DEFAULT_IGNORE = set()
+
+_MIN_WORD_LENGTH = 2            # zero to disable
+
+def terms_without_stopwords(lang_code: str, text: str) -> List[str]:
+    """
+    backwards compatibility: take text for single document, return terms
+    """
+    return terms_without_stopwords_list(lang_code, [text])[0]
+
+def terms_without_stopwords_list(lang_code: str, texts: list[str],
+                                 min_word_length: int = _MIN_WORD_LENGTH) -> List[List[str]]:
+    """
+    take list of documents, return list of token lists
+    (for both total term counts and per-document counts)
+    """
     try:
         lang_stopwords = stopwords_for_language(lang_code)
     except RuntimeError:
         # no stopwords for this language, so just let them all through
         logger.info(f"No stopwords for {lang_code}")
         lang_stopwords = set()
+    ignore = _IGNORE_BY_LANG.get(lang_code, _DEFAULT_IGNORE)
 
-    if remove_punctuation:
-        text = PUNCTUATION_RE.sub('', text)
-    else:
+    # See https://github.com/mediacloud/mc-providers/issues/54
+    # "xx" means the multilingual, language-agnostic tokenization
+    nlp = spacy.blank("xx")
+
+    results: list[list[str]] = []   # list of list of terms
+    for text in texts:
+        terms: list[str] = []
+
         # from https://github.com/mediacloud/backend/blob/master/apps/common/src/python/mediawords/languages/__init__.py#L128
         # Normalize apostrophe so that "it’s" and "it's" get counted together
+        # NOTE: https://stackoverflow.com/questions/67229023/correctly-tokenize-english-contractions-with-unicode-apostrophes
+        # has a longer list: '\u02B9', '\u02BB', '\u02BC', '\u02BD', '\u02C8', '\u02CA', '\u02CB'
         text = text.replace("’", "'")
 
-    terms = text.lower().split()
-    if lang_stopwords:
-        ok_terms = [term for term in terms if term not in lang_stopwords]
-        return ok_terms
-    else:
-        return terms
+        for t in nlp(text):
+            if t.is_punct or t.is_space or t.is_currency or len(t.text) < min_word_length:
+                continue
+            term = t.lower_
+            if term in lang_stopwords or term in ignore:
+                continue
+            terms.append(term)
+        results.append(terms)
+    return results

--- a/mc_providers/language/__init__.py
+++ b/mc_providers/language/__init__.py
@@ -64,7 +64,7 @@ def stopwords_for_language(lang_code: str) -> set:
 _IGNORE_BY_LANG = {
     "en": set(["'s"]),
 }
-_DEFAULT_IGNORE = set()
+_DEFAULT_IGNORE: set[str] = set()
 
 _MIN_WORD_LENGTH = 2            # zero to disable
 

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -156,7 +156,7 @@ class OnlineNewsAbstractProvider(ContentProvider):
         results = dict(results_counter)
             
         # and clean up results to return
-        top_terms = [make_term(term=t.lower(), count=c, sample_size=sample_size)
+        top_terms = [make_term(term=t.lower(), count=c, doc_count=0, sample_size=sample_size)
                      for t, c in results.items()
                      if t.lower() not in stopwords]
         top_terms = sorted(top_terms, key=lambda x:x["count"], reverse=True)

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -10,9 +10,10 @@ from operator import itemgetter
 
 # PyPI:
 import statsd
+from sigfig import sigfig
 
 from .exceptions import MissingRequiredValue, QueryingEverythingUnsupportedQuery
-from .language import terms_without_stopwords
+from .language import terms_without_stopwords_list
 
 logger = logging.getLogger(__name__) # for trace
 logger.setLevel(logging.DEBUG)
@@ -57,7 +58,8 @@ class Language(TypedDict):
     """
     language: str
     value: int
-    ratio: float                # really fraction?!
+    ratio: float                # rounded
+    sample_size: int
 
 class Source(TypedDict):
     """
@@ -66,13 +68,16 @@ class Source(TypedDict):
     source: str
     count: int
 
-class Term(TypedDict):
+class _Term(TypedDict):         # use Terms, terms_from_counts
     """
     list element in return value for words method
     """
     term: str
     count: int
-    ratio: float                # really fraction?!
+    ratio: float                # rounded!
+    sample_size: int
+
+Terms: TypeAlias = list[_Term]
 
 class Trace:
     # less noisy things, with lower numbers
@@ -82,6 +87,35 @@ class Trace:
     QSTR = 50            # query string/args
     # even more noisy things, with higher numbers
     ALL = 1000
+
+def ratio_with_sigfigs(count: int, sample_size: int) -> float:
+    """
+    try to prevent fractions with 17 or 18 digits
+    (CSV and JSON formatting don't appear to do ANY rounding)
+    """
+    sf = min(len(str(count)), len(str(sample_size)))
+    # in theory the above is correct, but force three digits:
+    sf = max(sf, 3)
+    # disable warnings: carps about 500/1000 having one sigfig!
+    # https://github.com/Bobzoon/SigFigs/ implements division with sigfigs,
+    # but is not a PyPI package.
+    return sigfig.round(count / sample_size, sigfigs=sf, warn=False)
+
+def make_term(term: str, count: int, sample_size: int) -> _Term:
+    """
+    the one place to format a dict for return from "words" method
+    """
+    sigfigs = len(str(sample_size))
+    return _Term(term=term, count=count,
+                 ratio=ratio_with_sigfigs(count, sample_size),
+                 sample_size=sample_size)
+
+def terms_from_counts(counts: collections.Counter[str], sample_size: int, limit) -> Terms:
+    """
+    format a Counter for return from library
+    """
+    return [make_term(term, count, sample_size)
+            for term, count in counts.most_common(limit)]
 
 class ContentProvider(ABC):
     """
@@ -167,7 +201,7 @@ class ContentProvider(ABC):
         raise NotImplementedError("Doesn't support fetching individual content.")
 
     def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
-              **kwargs: Any) -> list[Term]:
+              **kwargs: Any) -> Terms:
         raise NotImplementedError("Doesn't support top words.")
 
     def languages(self, query: str, start_date: dt.datetime, end_date: dt.datetime, **kwargs: Any) -> list[Language]:
@@ -251,7 +285,11 @@ class ContentProvider(ABC):
             sampled_count += len(page)
             [counts.update(t.get('language', "UNK") for t in page)]
         # clean up results
-        results = [Language(language=w, value=c, ratio=c/sampled_count) for w, c in counts.most_common(limit)]
+        results = [Language(language=w,
+                            value=c,
+                            ratio=ratio_with_sigfigs(c, sampled_count), # sampled data
+                            sample_size=sampled_count)
+                   for w, c in counts.most_common(limit)]
         return results
 
     def _sample_titles(self, query: str, start_date: dt.datetime, end_date: dt.datetime, sample_size: int,
@@ -264,26 +302,42 @@ class ContentProvider(ABC):
 
     # use this if you need to sample some content for top words
     def _sampled_title_words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
-                             **kwargs: Any) -> list[Term]:
+                             **kwargs: Any) -> Terms:
         # support sample_size kwarg
         sample_size = kwargs.pop('sample_size', self.WORDS_SAMPLE)
-        # NOTE! english stopwords contain contractions!!!
-        remove_punctuation = bool(kwargs.pop("remove_punctuation", True)) # XXX TEMP?
 
-        # grab a sample and count terms as we page through it
+        # grab a sample and collect by like language as we page through it
+        # (spacy tokenizer has high startup cost)
+        titles: dict[str, list[str]] = collections.defaultdict(list)
         sampled_count = 0
-        counts: collections.Counter = collections.Counter()
+        title_count = 0
         for page in self._sample_titles(query, start_date, end_date, sample_size, **kwargs):
             sampled_count += len(page)
-            [counts.update(terms_without_stopwords(t.get('language', 'UNK'), t['title'], remove_punctuation)) for t in page  if 'title' in t]
+            for story in page:
+                if "title" in story:
+                    titles[story.get("language", 'UNK')].append(story["title"])
+                    title_count += 1
+
             needed = sample_size - sampled_count
             if needed <= 0:
                 break           # quit once sample_size filled
             if needed < sample_size:
                 sample_size = needed # don't overfill
 
-        # clean up results
-        results = [Term(term=w, count=c, ratio=c/sampled_count) for w, c in counts.most_common(limit)]
+        # now tokenize, removing stopwords and tally
+        term_counts: collections.Counter = collections.Counter() # total appearances of a term
+        doc_counts: collections.Counter = collections.Counter()  # number of documents with a term
+
+        # spacy init is expensive, so call with bunches of titles
+        # in groups by language, for stopword processing
+        for language, title_list in titles.items():
+            for word_list in terms_without_stopwords_list(language, title_list): # takes min_length
+                this_doc_counts = collections.Counter(word_list)
+                term_counts.update(this_doc_counts)
+                doc_counts.update(this_doc_counts.keys())
+
+        # clean up results (used to use sampled_count)
+        results = terms_from_counts(term_counts, title_count, limit)
         self.trace(Trace.RESULTS, "_sampled_title_words %r", results)
         return results
 
@@ -362,7 +416,7 @@ class ContentProvider(ABC):
 
         env_var = self._env_var(variable)
         try:
-            # 1. Look for OBJ_NAME_VARIABLE env var, returns value if it exits.
+            # 1. Look for OBJ_NAME_VARIABLE env var, returns value if it exists.
             val = int(os.environ[env_var])
             self.trace(Trace.ARGS, "%r env %s %d", self, env_var, val)
             return val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "mediacloud == 4.*",
     "elasticsearch == 8.17.*", # keep in sync w/ ES major version?
     "elasticsearch-dsl == 8.17.*", # keep in sync w/ ES major version!
+    "sigfig == 1.1.*",
+    "spacy == 3.8.*",
     "statsd_client == 1.0.*",
 ]
 


### PR DESCRIPTION
I started with the intention of doing just the tokenization change, https://github.com/mediacloud/mc-providers/issues/54 but I the tokenization routine results feed into returning document counts, so I ended up addressing much, if not all of https://github.com/mediacloud/mc-providers/issues/55 as well!
