### PR TITLE
Accept "seconds" argument to cache decorator; Fix sigfig warnings

### DIFF
--- a/mc_providers/cache.py
+++ b/mc_providers/cache.py
@@ -20,9 +20,15 @@ class CachingManager():
 
     # typing from https://stackoverflow.com/questions/47060133/python-3-type-hinting-for-decorator
     @classmethod
-    def cache(cls, custom_prefix_for_key: Optional[str] = None, kwargs_to_ignore: Iterable[str] = []) -> Callable[[Callable[Param, RetType]], Callable[Param, RetType]]:
+    def cache(cls, custom_prefix_for_key: Optional[str] = None,
+              kwargs_to_ignore: Iterable[str] = [],
+              seconds: Optional[int] = None) -> Callable[[Callable[Param, RetType]], Callable[Param, RetType]]:
         """
         @param custom_prefix_for_key: if specified, will be used in place of function name for cache_key generation
+        @param kwargs_to_ignore: if specified, list of kwargs not to include in generated key
+        @param seconds: if specified, number of seconds to cache data
+            (CachingManager.cache_function MUST accept _cache_seconds
+            in kwargs, and MUST pop it before calling the decorated function)
         """
         def decorator(fn: Callable[Param, RetType]) -> Callable[Param, RetType]:
             # WISH: detect if 'fn' is being declared as a method to a ContentProvider!!
@@ -40,6 +46,8 @@ class CachingManager():
                         for kw in kwargs_to_ignore:
                             if kw in kwargs:
                                 kwargs.pop(kw)
+                    if seconds is not None:
+                        kwargs["_cache_seconds"] = seconds
                     results, was_cached = cls.cache_function(fn, cache_prefix, *args, **kwargs)
                     return results
                 else:

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -4,6 +4,7 @@ import importlib.metadata       # to get version for SOFTWARE_ID
 import logging
 import os
 import re
+import warnings
 from abc import ABC
 from typing import Any, Generator, Iterable, NoReturn, TypeAlias, TypedDict
 from operator import itemgetter
@@ -116,6 +117,12 @@ class Trace:
     # even more noisy things, with higher numbers
     ALL = 1000
 
+# disable warnings: carps about 500/1000 having one sigfig!
+# https://github.com/Bobzoon/SigFigs/ implements division with sigfigs,
+# but is not a PyPI package.
+warnings.filterwarnings('ignore', category=UserWarning,
+                        message=r".*\d+ significant figures requested from number with only \d+ .*")
+
 def ratio_with_sigfigs(count: int, sample_size: int) -> float:
     """
     try to prevent fractions with 17 or 18 digits
@@ -124,10 +131,7 @@ def ratio_with_sigfigs(count: int, sample_size: int) -> float:
     sf = min(len(str(count)), len(str(sample_size)))
     # in theory the above is correct, but force three digits:
     sf = max(sf, 3)
-    # disable warnings: carps about 500/1000 having one sigfig!
-    # https://github.com/Bobzoon/SigFigs/ implements division with sigfigs,
-    # but is not a PyPI package.
-    return sigfig.round(count / sample_size, sigfigs=sf, warn=False)
+    return sigfig.round(count / sample_size, sigfigs=sf)
 
 def make_term(term: str, count: int, doc_count: int, sample_size: int) -> _Term:
     """

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -8,6 +8,8 @@ import mediacloud.api
 import os
 from typing import List
 
+import pytest
+
 from mc_providers.onlinenews import OnlineNewsWaybackMachineProvider
 from mc_providers import (provider_for, PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD,
                           PLATFORM_SOURCE_MEDIA_CLOUD_OLD, PLATFORM_SOURCE_WAYBACK_MACHINE)
@@ -117,6 +119,7 @@ class OnlineNewsWaybackMachineProviderTest(unittest.TestCase):
             found_story_count += len(page)
         assert found_story_count == story_count
 
+    @pytest.mark.filterwarnings("ignore:.*significant figures.*:UserWarning")
     def test_words(self):
         results = self._provider.words("coronavirus", dt.datetime(2023, 12, 1),
                                        dt.datetime(2023, 12, 5))

--- a/stubs/sigfig/sigfig.pyi
+++ b/stubs/sigfig/sigfig.pyi
@@ -2,6 +2,6 @@
 just what we use
 """
 
-def round(number: float, *, sigfigs: int, warn: bool) -> float:
+def round(number: float, *, sigfigs: int) -> float:
     ...
 


### PR DESCRIPTION
* Support for "_cache_seconds" already merged in web-search.
* Fix 'make test'