### PR TITLE
just renaming things

### DIFF
--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -156,10 +156,10 @@ class OnlineNewsAbstractProvider(ContentProvider):
         results = dict(results_counter)
             
         # and clean up results to return
-        top_terms = [make_term(term=t.lower(), count=c, doc_count=0, sample_size=sample_size)
+        top_terms = [make_term(term=t.lower(), term_count=c, doc_count=0, sample_size=sample_size)
                      for t, c in results.items()
                      if t.lower() not in stopwords]
-        top_terms = sorted(top_terms, key=lambda x:x["count"], reverse=True)
+        top_terms = sorted(top_terms, key=lambda x:x["term_count"], reverse=True)
         return top_terms
 
     # Chunk'd

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -100,8 +100,8 @@ class _Term(TypedDict):
     use make_term, terms_from_counts to create
     """
     term: str
-    count: int                  # total number of appearances
-    ratio: float                # now rounded!
+    term_count: int                  # total number of appearances
+    term_ratio: float                # now rounded!
     doc_count: int              # number of documents appeared in
     doc_ratio: float            # rounded
     sample_size: int            # number of documents sampled

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -138,7 +138,7 @@ def make_term(term: str, term_count: int, doc_count: int, sample_size: int) -> _
     the one place to format a dict for return from "words" method
     """
     return _Term(term=term, term_count=term_count,
-                 term_ratio=ratio_with_sigfigs(count, sample_size),
+                 term_ratio=ratio_with_sigfigs(term_count, sample_size),
                  doc_count=doc_count,
                  doc_ratio=ratio_with_sigfigs(doc_count, sample_size),
                  sample_size=sample_size)

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -150,8 +150,8 @@ def terms_from_counts(term_counts: collections.Counter[str],
     """
     format a Counter for return from library
     """
-    return [make_term(term, count, doc_counts[term], sample_size)
-            for term, count in term_counts.most_common(limit)]
+    return [make_term(term, term_count, doc_counts[term], sample_size)
+            for term, term_count in term_counts.most_common(limit)]
 
 class ContentProvider(ABC):
     """

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -133,12 +133,12 @@ def ratio_with_sigfigs(count: int, sample_size: int) -> float:
     sf = max(sf, 3)
     return sigfig.round(count / sample_size, sigfigs=sf)
 
-def make_term(term: str, count: int, doc_count: int, sample_size: int) -> _Term:
+def make_term(term: str, term_count: int, doc_count: int, sample_size: int) -> _Term:
     """
     the one place to format a dict for return from "words" method
     """
-    return _Term(term=term, count=count,
-                 ratio=ratio_with_sigfigs(count, sample_size),
+    return _Term(term=term, term_count=term_count,
+                 term_ratio=ratio_with_sigfigs(count, sample_size),
                  doc_count=doc_count,
                  doc_ratio=ratio_with_sigfigs(doc_count, sample_size),
                  sample_size=sample_size)

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -125,8 +125,8 @@ class OnlineNewsWaybackMachineProviderTest(unittest.TestCase):
                                        dt.datetime(2023, 12, 5))
         last_count = 99999999999
         for item in results:
-            assert last_count >= item['count']
-            last_count = item['count']
+            assert last_count >= item['term-count']
+            last_count = item['term-count']
 
     def test_top_sources(self):
         results = self._provider.sources("coronavirus", dt.datetime(2023, 11, 1),

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -125,8 +125,8 @@ class OnlineNewsWaybackMachineProviderTest(unittest.TestCase):
                                        dt.datetime(2023, 12, 5))
         last_count = 99999999999
         for item in results:
-            assert last_count >= item['term-count']
-            last_count = item['term-count']
+            assert last_count >= item['term_count']
+            last_count = item['term_count']
 
     def test_top_sources(self):
         results = self._provider.sources("coronavirus", dt.datetime(2023, 11, 1),


### PR DESCRIPTION
Pending some tests, for 4.0 release.
count -> term-count and ratio -> term-ratio, where relevant to the fieldnames in the term aggregations. 
NB: will have to sync upgrading web-search to accommodate this change. 