### PR TITLE
single commit for third go-round on "use_subindex_list"

### DIFF
--- a/mc_providers/cache.py
+++ b/mc_providers/cache.py
@@ -27,8 +27,8 @@ class CachingManager():
         @param custom_prefix_for_key: if specified, will be used in place of function name for cache_key generation
         @param kwargs_to_ignore: if specified, list of kwargs not to include in generated key
         @param seconds: if specified, number of seconds to cache data
-            (CachingManager.cache_function MUST accept _cache_seconds
-            in kwargs, and MUST pop it before calling the decorated function)
+            (if present/set CachingManager.cache_function MUST accept
+            _cache_seconds in kwargs, and MUST pop it!)
         """
         def decorator(fn: Callable[Param, RetType]) -> Callable[Param, RetType]:
             # WISH: detect if 'fn' is being declared as a method to a ContentProvider!!

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -111,6 +111,7 @@ Terms: TypeAlias = list[_Term]
 class Trace:
     # less noisy things, with lower numbers
     STATS = 5
+    SUBINDICES = 8
     ARGS = 10            # constructor args
     RESULTS = 20
     QSTR = 50            # query string/args


### PR DESCRIPTION
Defaults to off, but can be enabled by provider constructor arg or environment variable setting.

When enabled:
* retrieves and caches maximum `indexed_date` per ILM subindex
* if search (publication) `start_date` more than 31 days in ahead of last `indexed_date` for an index, the index (and all previous indicies) is skipped.

Assumes per-index last indexed_date increase in each successive ILM index.
