### PR TITLE
Throw exception for OnlineNewsWaybackProvider.words, as the queries often timeout and results are not fully supported when they do not. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/*
 build
 mc_providers.egg-info
 .env
+.DS_STORE

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -412,7 +412,7 @@ class OnlineNewsWaybackMachineProvider(OnlineNewsAbstractProvider):
 
     def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
               **kwargs: Any) -> Terms:
-        raise PermanentProviderException("Term Queries against the WaybackMachine are not supported at this time")
+        raise PermanentProviderException("Top Words results are not supported for Wayback Machine queries at this time")
 
 ################
 # helpers for formatting url_search_strings (only enabled for MC)

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -410,6 +410,9 @@ class OnlineNewsWaybackMachineProvider(OnlineNewsAbstractProvider):
         # important to keep this unique among platforms so that the caching works right
         return "OnlineNewsWaybackMachineProvider"
 
+    def words(self, query: str, start_date: dt.datetime, end_date: dt.datetime, limit: int = 100,
+              **kwargs: Any) -> Terms:
+        raise PermanentProviderException("Term Queries against the WaybackMachine are not supported at this time")
 
 ################
 # helpers for formatting url_search_strings (only enabled for MC)


### PR DESCRIPTION
Permanent Exception?