### PR TITLE
Add Trace.RAW_{QUERY,RESPONSE}

### DIFF
--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -973,6 +973,9 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
             # basis. If set, it overrides the index-level setting"
             search = search.params(request_cache=False)
 
+        if self.trace_enabled(Trace.RAW_QUERY):
+            self.trace(Trace.RAW_QUERY, "query %r", search.to_dict())
+
         try:
             res = search.execute(**execute_args)
         except elasticsearch.exceptions.TransportError as e:
@@ -1000,6 +1003,8 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
             raise PermanentProviderException(short, long) from e
 
         logger.debug("MC._search ES took %s ms", getattr(res, "took", -1))
+        if self.trace_enabled(Trace.RAW_RESPONSE):
+            self.trace(Trace.RAW_RESPONSE, "response %r", res.to_dict())
 
         if (pdata := getattr(res, "profile", None)):
             self._process_profile_data(pdata)  # displays ES total time

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -122,8 +122,10 @@ class Trace:
     STATS = 5
     SUBINDICES = 8
     ARGS = 10            # constructor args
-    RESULTS = 20
-    QSTR = 50            # query string/args
+    RESULTS = 20         # provider method results
+    QSTR = 50            # provider method query string/args
+    RAW_QUERY = 60       # query as sent to search engine
+    RAW_RESPONSE = 70    # raw query results
     # even more noisy things, with higher numbers
     ALL = 1000
 
@@ -496,6 +498,13 @@ class ContentProvider(ABC):
         cls._trace = level
 
     @classmethod
+    def trace_enabled(cls, level: int) -> bool:
+        """
+        call to avoid unnecessary formatting before calling trace
+        """
+        return cls._trace >= level
+
+    @classmethod
     def trace(cls, level: int, format: str, *args: Any) -> None:
         """
         like logger.debug, but with additional gatekeeping.  trace level
@@ -506,7 +515,7 @@ class ContentProvider(ABC):
         See initialization of _trace above to see where the default
         value comes from
         """
-        if cls._trace >= level:
+        if cls.trace_enabled(level):
             logger.debug(format, *args)
 
     def __incr(self, name: str) -> None:


### PR DESCRIPTION
Allows display of raw ES query by calling `provider.set_trace(mc_providers.provider.Trace.RAW_QUERY)`
(where provider can be an instance, or the class: trace level is a class member to allow tracing class methods)
`Trace.RAW_RESPONSE` will log raw ES response as well