### PR TITLE
fixed mediacloud depedency spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "wayback-news-search == 1.*",
     "fasttext == 0.9.*",
     "mediacloud-metadata >= 1.4.0",
-    "mediacloud >= 5.*",
+    "mediacloud >= 5",
     "elasticsearch == 8.17.*", # keep in sync w/ ES major version?
     "elasticsearch-dsl == 8.17.*", # keep in sync w/ ES major version!
     "sigfig == 1.1.*",


### PR DESCRIPTION
Had it wrong on #87. Once I tried it the pip error said `invalid metadata: .* suffix can only be used with `==` or `!=` operators`! So I tweaked and tested this fix.