### PR TITLE
Support (likely dangerous) paging through random results

### DIFF
--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -637,7 +637,7 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
 
         # after pop-ing any local-only args:
         super().__init__(**kwargs)
-
+        self._base_url = "http://localhost:9200"
         eshosts = self._base_url.split(",") # comma separated list of http://SERVER:PORT
 
         # Retries without delay (never mind backoff!)
@@ -1436,51 +1436,114 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
                     res[field] = None
         return res
 
-    def random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
-                      page_size: int, fields: list[str], **kwargs: Any) -> AllItems:
-        """
-        Returns generator to allow pagination, but currently returns only
-        single page; actual pagination may require more work (passing
-        "seed" and "field" arguments to RandomSample).  Maybe foist
-        issue on caller and require "seed" argument??
 
-        To implement pagination in web-search API, would need to have
-        a method here that takes and returns a pagination token that
-        this method calls...  Perhaps paged_items could do the job
-        when passed a "randomize" argument???
-        """
-        if not fields:
-            raise ValueError("random_sample requires fields list")
-
+    def _safe_max_random_sample_page_size(self, page_size: int, field_count: int) -> int:
         # max controlled by index-level index.max_result_window, default is 10K.
         # allows 5K samples for lang/title pairs (for top words):
-        max_page = 10000 // len(fields)
+        max_page = 10000 // field_count
         if page_size > max_page:
-            page_size = max_page
+            return max_page
+        return page_size
 
+
+    def _field_names_for_elasticsearch(self, fields: list[str]) -> ES_Fieldnames:
         # convert requested external field names to ES field names to request
         es_fields: ES_Fieldnames = [
             self._ES_FIELDS[f].es_field_name
             for f in fields
             if not self._ES_FIELDS[f].metadata # no need to ask for metadata
         ]
+        return es_fields
+
+
+    def random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                      page_size: int, fields: list[str], **kwargs: Any) -> AllItems:
+        """
+        Returns a single-page generator of randomly-ordered results.
+        For paginated access use paged_random_sample instead.
+        """
+        if not fields:
+            raise ValueError("random_sample requires fields list")
+
+        safe_page_size = self._safe_max_random_sample_page_size(page_size, len(fields))
+        es_fields = self._field_names_for_elasticsearch(fields)
 
         search = self._basic_search(query, start_date, end_date, **kwargs)\
                      .query(
                          FunctionScore(
                              functions=[
-                                 RandomScore(
-                                     # needed for 100% reproducibility (ie; if paging results)
-                                     # seed=int, field="fieldname"
-                                 )
+                                 RandomScore()
                              ]
                          )
                      )\
                      .source(es_fields)\
-                     .extra(size=page_size)
+                     .extra(size=safe_page_size)
 
         hits = self._search_hits(search, "random-sample")
         yield [self._hit_to_row(hit, fields) for hit in hits] # just one page
+
+    def paged_random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                            page_size: int, fields: list[str], **kwargs: Any) -> tuple[list[dict], Optional[str]]:
+        """
+        Return one page of randomly-ordered results and a pagination token.
+
+        Pass pagination_token=None on the first call; pass the returned token on
+        each subsequent call to advance through pages.  The seed embedded in the
+        token keeps the random ordering stable across pages so results are
+        non-overlapping.  Optionally supply seed=<int> on the first call to force
+        a specific ordering (useful for reproducible tests or re-runs).
+
+        WARNING: each page request re-scores ALL matching documents across shards
+        (RandomScore has no index structure to resume from).  Cost is O(N) per
+        page where N is the matching document count, so total cost grows linearly
+        with the number of pages fetched.  Keep page counts small (single digits)
+        and prefer large page_size values to minimise the number of round trips.
+        """
+        if not fields:
+            raise ValueError("paged_random_sample requires fields list")
+
+        safe_page_size = self._safe_max_random_sample_page_size(page_size, len(fields))
+        pagination_token = kwargs.pop("pagination_token", None)
+
+        # pull seed out of pagination_token returned
+        if pagination_token:
+            parts = _b64_decode_page_token(pagination_token).split(_SORT_KEY_SEP)
+            seed = int(parts[0])
+            after: list | None = [float(parts[1]), parts[2]]
+        else:
+            seed = kwargs.pop("seed", random.randint(0, 2**31 - 1))
+            after = None
+
+        es_fields = self._field_names_for_elasticsearch(fields)
+
+        search = self._basic_search(query, start_date, end_date, **kwargs)\
+                     .query(
+                         FunctionScore(
+                             functions=[
+                                 RandomScore(seed=seed, field="_seq_no")
+                             ]
+                         )
+                     )\
+                     .source(es_fields)\
+                     .extra(size=safe_page_size)\
+                     .sort({"_score": "desc"}, _SECONDARY_SORT_ARGS)
+
+        if after is not None:
+            search = search.extra(search_after=after)
+
+        hits = self._search_hits(search, "paged-random-sample")
+        if not hits:
+            return ([], None)
+
+        new_pt: str | None = None
+        if len(hits) == page_size:
+            sort_vals = hits[-1].meta.sort
+            new_pt = _b64_encode_page_token(
+                _SORT_KEY_SEP.join([str(seed), str(sort_vals[0]), str(sort_vals[1])])
+            )
+
+        rows = [self._hit_to_row(hit, fields) for hit in hits]
+        return rows, new_pt
 
     @classmethod
     def fields(cls, expanded: bool = False) -> list[str]:

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -1399,14 +1399,10 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
 
         new_pt: str | None = None
         if len(hits) == page_size:
+            sort_key_vals = hits[-1].meta.sort
             if randomize:
-                sort_vals = hits[-1].meta.sort  # [score, _doc]
-                new_pt = _b64_encode_page_token(
-                    _SORT_KEY_SEP.join([str(sort_vals[0]), str(sort_vals[1]), str(seed)])
-                )
+                sort_key_vals = [sort_key_vals[0], sort_key_vals[1], seed]
             else:
-                # generate paging token from all sort keys of last item:
-                sort_key_vals = hits[-1].meta.sort
                 # indexed_date is nanoseconds, returned as int, but
                 # epoch_nanos not accepted by date parser, so format
                 # with only microseconds (which is what is fed in)
@@ -1417,8 +1413,8 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
                                               time.gmtime(epoch_secs))
                     last_nanos = epoch_nanos % NS_PER_SEC
                     sort_key_vals[0] = f"{last_date}.{last_nanos:09d}Z"
-                new_pt = _b64_encode_page_token(
-                    _SORT_KEY_SEP.join([str(key) for key in sort_key_vals]))
+            new_pt = _b64_encode_page_token(
+                _SORT_KEY_SEP.join([str(key) for key in sort_key_vals]))
 
         fields = self.fields(expanded)
         rows = [self._hit_to_row(h, fields, True) for h in hits]

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -637,7 +637,6 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
 
         # after pop-ing any local-only args:
         super().__init__(**kwargs)
-        self._base_url = "http://localhost:9200"
         eshosts = self._base_url.split(",") # comma separated list of http://SERVER:PORT
 
         # Retries without delay (never mind backoff!)

--- a/mc_providers/onlinenews.py
+++ b/mc_providers/onlinenews.py
@@ -1325,7 +1325,16 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
         Pass `None` as first `pagination_token`, after that pass
         value returned by previous call, until `None` returned.
 
-        `kwargs` may contain: `sort_field` (str), `sort_order` (str), `expanded` (bool)
+        `kwargs` may contain: `sort_field` (str), `sort_order` (str), `expanded` (bool),
+        `randomize` (bool), `seed` (int)
+
+        When `randomize=True` the results are returned in a deterministic random order
+        stable across pages for a given seed.  The seed is embedded in the returned
+        token so subsequent calls do not need to re-supply `randomize` or `seed`.
+
+        WARNING: randomized pagination re-scores ALL matching documents on every
+        request (O(N) per page where N = matching doc count).  Keep the number of
+        pages fetched small and prefer large page_size values.
         """
         logger.debug("MC._paged_items q: %s: %s e: %s ps: %d",
                      query, start_date, end_date, page_size)
@@ -1336,37 +1345,52 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
         sort_field = kwargs.pop("sort_field", _DEF_SORT_FIELD)
         sort_order = kwargs.pop("sort_order", _DEF_SORT_ORDER)
         pagination_token = kwargs.pop("pagination_token", None)
+        randomize = kwargs.pop("randomize", False)
+        seed_arg = kwargs.pop("seed", None)
 
-        # NOTE! depends on client limiting to reasonable choices!!
-        # (full text might leak data, or causes memory exhaustion!)
-        # originally took internal sort_field names only, now accept
-        # both, prefering to intrepret as external first
-        # (the default indexed_date name is same inside and out)
-        sf = self._ES_FIELDS.get(sort_field)
-        if sf and not sf.metadata:
-            sort_field = sf.es_field_name
-        if sort_field not in self._fields(expanded):
-            raise ValueError(sort_field)
-        if sort_order not in ["asc", "desc"]:
-            raise ValueError(sort_order)
+        # Decode token; a 3-part token signals randomized pagination (seed is last).
+        # important to use `search_after` instead of 'from' for memory reasons
+        # related to paging through more than 10k results.
+        after: list | None = None
+        seed: int | None = None
+        if pagination_token:
+            parts = _b64_decode_page_token(pagination_token).split(_SORT_KEY_SEP)
+            if len(parts) == 3:  # random token: [score, _doc, seed]
+                randomize = True
+                after = [float(parts[0]), int(parts[1])]
+                seed = int(parts[2])
+            else:               # regular token: two sort-key values
+                after = parts
 
-        # see discussion above at _SECONDARY_SORT_ARGS declaration
-        sort_opts = [
-            {sort_field: sort_order},
-            _SECONDARY_SORT_ARGS
-        ]
+        if randomize:
+            if seed is None:
+                seed = seed_arg if seed_arg is not None else random.randint(0, 2**31 - 1)
+        else:
+            # NOTE! depends on client limiting to reasonable choices!!
+            # (full text might leak data, or causes memory exhaustion!)
+            # originally took internal sort_field names only, now accept
+            # both, prefering to intrepret as external first
+            # (the default indexed_date name is same inside and out)
+            sf = self._ES_FIELDS.get(sort_field)
+            if sf and not sf.metadata:
+                sort_field = sf.es_field_name
+            if sort_field not in self._fields(expanded):
+                raise ValueError(sort_field)
+            if sort_order not in ["asc", "desc"]:
+                raise ValueError(sort_order)
 
         search = self._basic_search(query, start_date, end_date, expanded=expanded, **kwargs)\
-                     .extra(size=page_size)\
-                     .sort(*sort_opts)
+                     .extra(size=page_size)
 
-        if pagination_token:
-            # may return multiple keys:
-            after = _b64_decode_page_token(pagination_token).split(_SORT_KEY_SEP)
+        if randomize:
+            search = search\
+                .query(FunctionScore(functions=[RandomScore(seed=seed, field="_seq_no")]))\
+                .sort({"_score": "desc"}, _SECONDARY_SORT_ARGS)
+        else:
+            # see discussion above at _SECONDARY_SORT_ARGS declaration
+            search = search.sort(*[{sort_field: sort_order}, _SECONDARY_SORT_ARGS])
 
-            # important to use `search_after` instead of 'from' for
-            # memory reasons related to paging through more than 10k
-            # results.
+        if after is not None:
             search = search.extra(search_after=after)
 
         hits = self._search_hits(search, "paged-items")
@@ -1375,20 +1399,26 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
 
         new_pt: str | None = None
         if len(hits) == page_size:
-            # generate paging token from all sort keys of last item:
-            sort_key_vals = hits[-1].meta.sort
-            # indexed_date is nanoseconds, returned as int, but
-            # epoch_nanos not accepted by date parser, so format
-            # with only microseconds (which is what is fed in)
-            if sort_field == "indexed_date":
-                epoch_nanos = sort_key_vals[0]
-                epoch_secs = epoch_nanos // NS_PER_SEC
-                last_date = time.strftime("%Y-%m-%dT%H:%M:%S",
-                                          time.gmtime(epoch_secs))
-                last_nanos = epoch_nanos % NS_PER_SEC
-                sort_key_vals[0] = f"{last_date}.{last_nanos:09d}Z"
-            new_pt = _b64_encode_page_token(
-                _SORT_KEY_SEP.join([str(key) for key in sort_key_vals]))
+            if randomize:
+                sort_vals = hits[-1].meta.sort  # [score, _doc]
+                new_pt = _b64_encode_page_token(
+                    _SORT_KEY_SEP.join([str(sort_vals[0]), str(sort_vals[1]), str(seed)])
+                )
+            else:
+                # generate paging token from all sort keys of last item:
+                sort_key_vals = hits[-1].meta.sort
+                # indexed_date is nanoseconds, returned as int, but
+                # epoch_nanos not accepted by date parser, so format
+                # with only microseconds (which is what is fed in)
+                if sort_field == "indexed_date":
+                    epoch_nanos = sort_key_vals[0]
+                    epoch_secs = epoch_nanos // NS_PER_SEC
+                    last_date = time.strftime("%Y-%m-%dT%H:%M:%S",
+                                              time.gmtime(epoch_secs))
+                    last_nanos = epoch_nanos % NS_PER_SEC
+                    sort_key_vals[0] = f"{last_date}.{last_nanos:09d}Z"
+                new_pt = _b64_encode_page_token(
+                    _SORT_KEY_SEP.join([str(key) for key in sort_key_vals]))
 
         fields = self.fields(expanded)
         rows = [self._hit_to_row(h, fields, True) for h in hits]
@@ -1440,109 +1470,34 @@ class OnlineNewsMediaCloudProvider(OnlineNewsAbstractProvider):
         # max controlled by index-level index.max_result_window, default is 10K.
         # allows 5K samples for lang/title pairs (for top words):
         max_page = 10000 // field_count
-        if page_size > max_page:
-            return max_page
-        return page_size
-
-
-    def _field_names_for_elasticsearch(self, fields: list[str]) -> ES_Fieldnames:
-        # convert requested external field names to ES field names to request
-        es_fields: ES_Fieldnames = [
-            self._ES_FIELDS[f].es_field_name
-            for f in fields
-            if not self._ES_FIELDS[f].metadata # no need to ask for metadata
-        ]
-        return es_fields
-
+        return min(page_size, max_page)
 
     def random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
                       page_size: int, fields: list[str], **kwargs: Any) -> AllItems:
         """
         Returns a single-page generator of randomly-ordered results.
-        For paginated access use paged_random_sample instead.
+        For multi-page random access, call paged_items with randomize=True directly.
         """
         if not fields:
             raise ValueError("random_sample requires fields list")
 
-        safe_page_size = self._safe_max_random_sample_page_size(page_size, len(fields))
-        es_fields = self._field_names_for_elasticsearch(fields)
+        page_size = self._safe_max_random_sample_page_size(page_size, len(fields))
 
-        search = self._basic_search(query, start_date, end_date, **kwargs)\
-                     .query(
-                         FunctionScore(
-                             functions=[
-                                 RandomScore()
-                             ]
-                         )
-                     )\
-                     .source(es_fields)\
-                     .extra(size=safe_page_size)
+        # Use expanded=True if any requested field lives in the expanded set
+        expanded = any(
+            self._ES_FIELDS[f].include == Include.EXPANDED
+            for f in fields if f in self._ES_FIELDS
+        )
 
-        hits = self._search_hits(search, "random-sample")
-        yield [self._hit_to_row(hit, fields) for hit in hits] # just one page
-
-    def paged_random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
-                            page_size: int, fields: list[str], **kwargs: Any) -> tuple[list[dict], Optional[str]]:
-        """
-        Return one page of randomly-ordered results and a pagination token.
-
-        Pass pagination_token=None on the first call; pass the returned token on
-        each subsequent call to advance through pages.  The seed embedded in the
-        token keeps the random ordering stable across pages so results are
-        non-overlapping.  Optionally supply seed=<int> on the first call to force
-        a specific ordering (useful for reproducible tests or re-runs).
-
-        WARNING: each page request re-scores ALL matching documents across shards
-        (RandomScore has no index structure to resume from).  Cost is O(N) per
-        page where N is the matching document count, so total cost grows linearly
-        with the number of pages fetched.  Keep page counts small (single digits)
-        and prefer large page_size values to minimise the number of round trips.
-        """
-        if not fields:
-            raise ValueError("paged_random_sample requires fields list")
-
-        safe_page_size = self._safe_max_random_sample_page_size(page_size, len(fields))
-        pagination_token = kwargs.pop("pagination_token", None)
-
-        # pull seed out of pagination_token returned
-        if pagination_token:
-            parts = _b64_decode_page_token(pagination_token).split(_SORT_KEY_SEP)
-            seed = int(parts[0])
-            after: list | None = [float(parts[1]), parts[2]]
-        else:
-            seed = kwargs.pop("seed", random.randint(0, 2**31 - 1))
-            after = None
-
-        es_fields = self._field_names_for_elasticsearch(fields)
-
-        search = self._basic_search(query, start_date, end_date, **kwargs)\
-                     .query(
-                         FunctionScore(
-                             functions=[
-                                 RandomScore(seed=seed, field="_seq_no")
-                             ]
-                         )
-                     )\
-                     .source(es_fields)\
-                     .extra(size=safe_page_size)\
-                     .sort({"_score": "desc"}, _SECONDARY_SORT_ARGS)
-
-        if after is not None:
-            search = search.extra(search_after=after)
-
-        hits = self._search_hits(search, "paged-random-sample")
-        if not hits:
-            return ([], None)
-
-        new_pt: str | None = None
-        if len(hits) == page_size:
-            sort_vals = hits[-1].meta.sort
-            new_pt = _b64_encode_page_token(
-                _SORT_KEY_SEP.join([str(seed), str(sort_vals[0]), str(sort_vals[1])])
-            )
-
-        rows = [self._hit_to_row(hit, fields) for hit in hits]
-        return rows, new_pt
+        page, _ = self.paged_items(
+            query, start_date, end_date,
+            page_size=page_size,
+            expanded=expanded,
+            randomize=True,
+            **kwargs
+        )
+        if page:
+            yield [{k: row[k] for k in fields if row.get(k) is not None} for row in page]
 
     @classmethod
     def fields(cls, expanded: bool = False) -> list[str]:

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -378,13 +378,6 @@ class ContentProvider(ABC):
                       page_size: int, fields: list[str], **kwargs: Any) -> AllItems:
         raise NotImplementedError("Doesn't support fetching random sample.")
 
-    def paged_random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
-                            page_size: int, fields: list[str], **kwargs: Any) -> tuple[list[dict], str | None]:
-        # kwargs may include: pagination_token (str | None), seed (int)
-        # This is implemented as a separate endpoint because it can be expensive to run on servers, so we
-        # want to be thoughtful about how / if we support it for external users
-        raise NotImplementedError("Doesn't support paginated random sample.")
-
     @classmethod
     def fields(cls, expanded: bool = False) -> list[str]:
         """

--- a/mc_providers/provider.py
+++ b/mc_providers/provider.py
@@ -376,11 +376,14 @@ class ContentProvider(ABC):
 
     def random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
                       page_size: int, fields: list[str], **kwargs: Any) -> AllItems:
-        # NOTE! same type signature as all_items (plus fields)
-        # Could be subsumed by passing keyword arguments (fields, randomize) to all_items?!
-        # A paged_ version would be needed for to expose a web-search API call
-        # (which would require a "seed" value to generate a consistent sequence)
         raise NotImplementedError("Doesn't support fetching random sample.")
+
+    def paged_random_sample(self, query: str, start_date: dt.datetime, end_date: dt.datetime,
+                            page_size: int, fields: list[str], **kwargs: Any) -> tuple[list[dict], str | None]:
+        # kwargs may include: pagination_token (str | None), seed (int)
+        # This is implemented as a separate endpoint because it can be expensive to run on servers, so we
+        # want to be thoughtful about how / if we support it for external users
+        raise NotImplementedError("Doesn't support paginated random sample.")
 
     @classmethod
     def fields(cls, expanded: bool = False) -> list[str]:

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -318,7 +318,7 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         # a VPN tunnel open to the Media Cloud production ES
         # with "export ONLINE_NEWS_MEDIA_CLOUD_ES_PROVIDER_BASE_URL=http://localhost:9200"
         self._provider = provider_for(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD,
-                                      software_id=__name__, session_id=os.environ.get("USER", "test-user"), base_url='http://localhost:9200')
+                                      software_id=__name__, session_id=os.environ.get("USER", "test-user"))
 
     # moved here 2025-03-18: no longer supported in Wayback Provider
     @pytest.mark.filterwarnings("ignore:.*significant figures.*:UserWarning")

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -318,7 +318,7 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         # a VPN tunnel open to the Media Cloud production ES
         # with "export ONLINE_NEWS_MEDIA_CLOUD_ES_PROVIDER_BASE_URL=http://localhost:9200"
         self._provider = provider_for(PLATFORM_ONLINE_NEWS, PLATFORM_SOURCE_MEDIA_CLOUD,
-                                      software_id=__name__, session_id=os.environ.get("USER", "test-user"))
+                                      software_id=__name__, session_id=os.environ.get("USER", "test-user"), base_url='http://localhost:9200')
 
     # moved here 2025-03-18: no longer supported in Wayback Provider
     @pytest.mark.filterwarnings("ignore:.*significant figures.*:UserWarning")
@@ -512,6 +512,64 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         self._test_random_sample(["id", "indexed_date", "language",
                                   "media_name", "media_url", "publish_date",
                                   "text", "title", "url"], page_size=2)
+
+    def test_paged_random_sample_no_overlap(self):
+        """Four consecutive pages share no document IDs."""
+        query = "biden"
+        start_date = dt.datetime(2020, 1, 1)
+        end_date = dt.datetime(2023, 12, 1)
+        fields = ["id", "title", "language", "media_name", "publish_date", "url", "language"]
+        page_size = 1000
+
+        all_ids: list[str] = []
+        token = None
+        for _ in range(10):
+            page, token = self._provider.paged_random_sample(
+                query, start_date, end_date,
+                page_size=page_size, fields=fields, pagination_token=token
+            )
+            assert len(page) == page_size
+            page_ids = [item["id"] for item in page]
+            assert not set(page_ids) & set(all_ids), "duplicate IDs found across pages"
+            all_ids.extend(page_ids)
+            assert token is not None
+
+    def test_paged_random_sample_reproducible(self):
+        """The same seed produces the same first page."""
+        query = "biden"
+        start_date = dt.datetime(2020, 1, 1)
+        end_date = dt.datetime(2023, 12, 1)
+        fields = ["id"]
+        page_size = 50
+        seed = 12345
+
+        page1, _ = self._provider.paged_random_sample(
+            query, start_date, end_date,
+            page_size=page_size, fields=fields, seed=seed
+        )
+        page2, _ = self._provider.paged_random_sample(
+            query, start_date, end_date,
+            page_size=page_size, fields=fields, seed=seed
+        )
+        assert [item["id"] for item in page1] == [item["id"] for item in page2]
+
+    def test_paged_random_sample_different_seeds(self):
+        """Different seeds produce different orderings."""
+        query = "biden"
+        start_date = dt.datetime(2020, 1, 1)
+        end_date = dt.datetime(2023, 12, 1)
+        fields = ["id"]
+        page_size = 100
+
+        page1, _ = self._provider.paged_random_sample(
+            query, start_date, end_date,
+            page_size=page_size, fields=fields, seed=1
+        )
+        page2, _ = self._provider.paged_random_sample(
+            query, start_date, end_date,
+            page_size=page_size, fields=fields, seed=2
+        )
+        assert [item["id"] for item in page1] != [item["id"] for item in page2]
 
     @staticmethod
     def inner_keys(tdc) -> set[str]:

--- a/mc_providers/test/test_onlinenews.py
+++ b/mc_providers/test/test_onlinenews.py
@@ -342,9 +342,16 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
         query = "*"
         start_date = dt.datetime(2020, 1, 1)
         end_date = dt.datetime(2023, 12, 1)
-        page1, next_token1 = self._provider.paged_items(query, start_date, end_date, expanded=True)
-        assert len(page1) > 0
-        for story in page1:
+        page, next_token = self._provider.paged_items(query, start_date, end_date, expanded=True)
+        assert len(page) > 0
+        for story in page:
+            assert "id" in story
+            assert "text" in story
+            assert len(story['text']) > 0
+        # test randomized sort order too
+        page, next_token = self._provider.paged_items(query, start_date, end_date, expanded=True, randomize=True)
+        assert len(page) > 0
+        for story in page:
             assert "id" in story
             assert "text" in story
             assert len(story['text']) > 0
@@ -470,9 +477,9 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
 
     # id requires special handling; test for no duplicates
     def test_random_id(self):
-        page_size = 10000
+        page_size = 1000
         results = self._collect_random_results("*", ["id"], page_size, None, None)
-        assert len(results) == page_size
+        self.assertEqual(len(results), page_size)
 
         # ensure no duplicates
         idlist = [s["id"] for s in results]
@@ -513,20 +520,21 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
                                   "media_name", "media_url", "publish_date",
                                   "text", "title", "url"], page_size=2)
 
-    def test_paged_random_sample_no_overlap(self):
-        """Four consecutive pages share no document IDs."""
+    def test_paged_items_random_no_overlap(self):
+        """Four consecutive randomized pages share no document IDs."""
         query = "biden"
         start_date = dt.datetime(2020, 1, 1)
         end_date = dt.datetime(2023, 12, 1)
-        fields = ["id", "title", "language", "media_name", "publish_date", "url", "language"]
-        page_size = 1000
+        page_size = 100
 
         all_ids: list[str] = []
         token = None
-        for _ in range(10):
-            page, token = self._provider.paged_random_sample(
+        for i in range(4):
+            page, token = self._provider.paged_items(
                 query, start_date, end_date,
-                page_size=page_size, fields=fields, pagination_token=token
+                page_size=page_size,
+                randomize=(i == 0),   # only needed on first call; token signals it after
+                pagination_token=token
             )
             assert len(page) == page_size
             page_ids = [item["id"] for item in page]
@@ -534,40 +542,38 @@ class OnlineNewsMediaCloudProviderTest(OnlineNewsWaybackMachineProviderTest):
             all_ids.extend(page_ids)
             assert token is not None
 
-    def test_paged_random_sample_reproducible(self):
+    def test_paged_items_random_reproducible(self):
         """The same seed produces the same first page."""
         query = "biden"
         start_date = dt.datetime(2020, 1, 1)
         end_date = dt.datetime(2023, 12, 1)
-        fields = ["id"]
         page_size = 50
         seed = 12345
 
-        page1, _ = self._provider.paged_random_sample(
+        page1, _ = self._provider.paged_items(
             query, start_date, end_date,
-            page_size=page_size, fields=fields, seed=seed
+            page_size=page_size, randomize=True, seed=seed
         )
-        page2, _ = self._provider.paged_random_sample(
+        page2, _ = self._provider.paged_items(
             query, start_date, end_date,
-            page_size=page_size, fields=fields, seed=seed
+            page_size=page_size, randomize=True, seed=seed
         )
         assert [item["id"] for item in page1] == [item["id"] for item in page2]
 
-    def test_paged_random_sample_different_seeds(self):
+    def test_paged_items_random_different_seeds(self):
         """Different seeds produce different orderings."""
         query = "biden"
         start_date = dt.datetime(2020, 1, 1)
         end_date = dt.datetime(2023, 12, 1)
-        fields = ["id"]
         page_size = 100
 
-        page1, _ = self._provider.paged_random_sample(
+        page1, _ = self._provider.paged_items(
             query, start_date, end_date,
-            page_size=page_size, fields=fields, seed=1
+            page_size=page_size, randomize=True, seed=1
         )
-        page2, _ = self._provider.paged_random_sample(
+        page2, _ = self._provider.paged_items(
             query, start_date, end_date,
-            page_size=page_size, fields=fields, seed=2
+            page_size=page_size, randomize=True, seed=2
         )
         assert [item["id"] for item in page1] != [item["id"] for item in page2]
 


### PR DESCRIPTION
For larger data pulls it is convenient to do a random sample. However the current feature only allows up to ~1000 results. This (AI-assisted) PR adds paging with big comments about how that can be dangerous if going over lots of pages. I'm thinking we put this in the API client behind an admin-only type check so that it isn't abused. I think internal users can be trusted to use it for infrequent data pulls (but maybe I'm wrong).

Unit tests assess basic functionality.